### PR TITLE
Add callbacks

### DIFF
--- a/lib/xgboost/booster.rb
+++ b/lib/xgboost/booster.rb
@@ -1,6 +1,6 @@
 module XGBoost
   class Booster
-    attr_accessor :best_iteration, :feature_names, :feature_types
+    attr_accessor :best_iteration, :feature_names, :feature_types, :best_score
 
     def initialize(params: nil, model_file: nil)
       @handle = ::FFI::MemoryPointer.new(:pointer)

--- a/lib/xgboost/booster.rb
+++ b/lib/xgboost/booster.rb
@@ -1,8 +1,9 @@
 module XGBoost
   class Booster
-    attr_accessor :best_iteration, :feature_names, :feature_types, :best_score
+    attr_accessor :best_iteration, :feature_names, :feature_types, :best_score, :params
 
     def initialize(params: nil, model_file: nil)
+      @params = params
       @handle = ::FFI::MemoryPointer.new(:pointer)
       check_result FFI.XGBoosterCreate(nil, 0, @handle)
       ObjectSpace.define_finalizer(@handle, self.class.finalize(handle_pointer.to_i))

--- a/lib/xgboost/callback_container.rb
+++ b/lib/xgboost/callback_container.rb
@@ -31,16 +31,18 @@ module XGBoost
       model
     end
 
+    # If ANY callback returns false, then EXIT
     def before_iteration(model: nil, epoch: nil)
-      callbacks.none? || callbacks.any? do |callback|
+      callbacks.none? || callbacks.all? do |callback|
         callback.before_iteration(model: model, epoch: epoch)
       end
     end
 
+    # If ANY callback returns false, then EXIT
     def after_iteration(model: nil, epoch: nil, res: nil)
       update_history(res)
 
-      callbacks.none? || callbacks.any? do |callback|
+      callbacks.none? || callbacks.all? do |callback|
         callback.after_iteration(model: model, epoch: epoch, history: history)
       end
     end

--- a/lib/xgboost/callback_container.rb
+++ b/lib/xgboost/callback_container.rb
@@ -1,0 +1,59 @@
+module XGBoost
+  class CallbackContainer
+    attr_reader :callbacks, :history
+
+    def initialize(callbacks)
+      @callbacks = callbacks
+      @history = {}
+
+      callbacks.each do |callback|
+        raise ArgumentError, 'callback must subclass XGBoost::TrainingCallback.' unless callback.is_a?(TrainingCallback)
+      end
+    end
+
+    def before_training(model: nil)
+      callbacks.each do |callback|
+        model = callback.before_training(model: model)
+        unless model.is_a?(XGBoost::Booster)
+          raise ArgumentError, "Callback #{callback.class}#before_training must return an instance of XGBoost::Booster"
+        end
+      end
+      model
+    end
+
+    def after_training(model: nil)
+      callbacks.each do |callback|
+        model = callback.after_training(model: model)
+        unless model.is_a?(XGBoost::Booster)
+          raise ArgumentError, "Callback #{callback.class}#after_training must return an instance of XGBoost::Booster"
+        end
+      end
+      model
+    end
+
+    def before_iteration(model: nil, epoch: nil)
+      callbacks.none? || callbacks.any? do |callback|
+        callback.before_iteration(model: model, epoch: epoch)
+      end
+    end
+
+    def after_iteration(model: nil, epoch: nil, res: nil)
+      update_history(res)
+
+      callbacks.none? || callbacks.any? do |callback|
+        callback.after_iteration(model: model, epoch: epoch, history: history)
+      end
+    end
+
+    private
+
+    def update_history(res)
+      res.each do |name, value|
+        data_name, metric_name = name.split('-', 2)
+        history[data_name] ||= {}
+        history[data_name][metric_name] ||= []
+        history[data_name][metric_name] << value
+      end
+    end
+  end
+end

--- a/lib/xgboost/training_callback.rb
+++ b/lib/xgboost/training_callback.rb
@@ -1,0 +1,23 @@
+module XGBoost
+  class TrainingCallback
+    def before_training(model: nil)
+      # Run before training starts
+      model
+    end
+
+    def after_training(model: nil)
+      # Run after training is finished
+      model
+    end
+
+    def before_iteration(model: nil, epoch: nil)
+      # Run before each iteration. Returns true when training should stop.
+      false
+    end
+
+    def after_iteration(model: nil, epoch: nil, history: nil)
+      # Run after each iteration. Returns true when training should stop.
+      false
+    end
+  end
+end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,0 +1,185 @@
+require_relative "test_helper"
+
+class CallbacksTest < Minitest::Test
+  class MockCallback < XGBoost::TrainingCallback
+    attr_reader :before_training_count, :after_training_count, :before_iteration_count, :after_iteration_count,
+                :before_training_args, :after_training_args, :before_iteration_args, :after_iteration_args, :history
+
+    def initialize
+      @before_training_count = 0
+      @after_training_count = 0
+      @before_iteration_count = 0
+      @after_iteration_count = 0
+      @before_training_args = []
+      @after_training_args = []
+      @before_iteration_args = []
+      @after_iteration_args = []
+      @history = {}
+    end
+
+    def before_training(model: nil)
+      @before_training_count += 1
+      model
+    end
+
+    def after_training(model: nil)
+      @after_training_count += 1
+      model
+    end
+
+    def before_iteration(model: nil, epoch: nil)
+      @before_iteration_count += 1
+      @before_iteration_args << { epoch: epoch }
+      return true
+    end
+
+    def after_iteration(model: nil, epoch: nil, history: nil)
+      @after_iteration_count += 1
+      @history = history
+      return true
+    end
+  end
+
+  def test_callback_raises_when_not_training_callback
+    num_boost_round = 10
+
+    assert_raises(ArgumentError, /callback must subclass XGBoost::TrainingCallback/) do
+      XGBoost.train(
+        regression_params,
+        regression_train,
+        num_boost_round: num_boost_round,
+        callbacks: ['not a callback'],
+        evals: [[regression_train, 'train'], [regression_test, 'eval']]
+      )
+    end
+  end
+
+  def test_callback
+    callback = MockCallback.new
+    num_boost_round = 10
+
+    XGBoost.train(
+      regression_params,
+      regression_train,
+      num_boost_round: num_boost_round,
+      callbacks: [callback],
+      evals: [[regression_train, 'train'], [regression_test, 'eval']]
+    )
+
+    assert_equal 1, callback.before_training_count
+    assert_equal 1, callback.after_training_count
+    assert_equal num_boost_round, callback.before_iteration_count
+    assert_equal num_boost_round, callback.after_iteration_count
+
+    # Verify arguments
+    train_rmse = callback.history['train']['rmse']
+    assert_equal num_boost_round, train_rmse.size
+    train_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+    eval_rmse = callback.history['eval']['rmse']
+    assert_equal num_boost_round, eval_rmse.size
+    eval_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+
+    epochs = callback.before_iteration_args.map { |e| e[:epoch] }
+    assert_equal (0...num_boost_round).to_a, epochs
+  end
+
+  def test_callback_breaks_on_before_iteration
+    callback = MockCallback.new
+    def callback.before_iteration(model: nil, epoch: nil)
+      @before_iteration_count += 1
+      @before_iteration_args << { epoch: epoch }
+      return (epoch % 2 == 0)
+    end
+    num_boost_round = 10
+
+    XGBoost.train(
+      regression_params,
+      regression_train,
+      num_boost_round: num_boost_round,
+      callbacks: [callback],
+      evals: [[regression_train, 'train'], [regression_test, 'eval']]
+    )
+
+    assert_equal 1, callback.before_training_count
+    assert_equal 1, callback.after_training_count
+    assert_equal 2, callback.before_iteration_count
+    assert_equal 1, callback.after_iteration_count
+
+    # Verify arguments
+    train_rmse = callback.history['train']['rmse']
+    assert_equal 1, train_rmse.size
+    train_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+    eval_rmse = callback.history['eval']['rmse']
+    assert_equal 1, eval_rmse.size
+    eval_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+
+    epochs = callback.before_iteration_args.map { |e| e[:epoch] }
+    assert_equal (0...2).to_a, epochs
+  end
+
+  def test_callback_breaks_on_after_iteration
+    callback = MockCallback.new
+    def callback.after_iteration(model: nil, epoch: nil, history: nil)
+      @after_iteration_count += 1
+      @history = history
+      return epoch < 7
+    end
+    num_boost_round = 10
+
+    XGBoost.train(
+      regression_params,
+      regression_train,
+      num_boost_round: num_boost_round,
+      callbacks: [callback],
+      evals: [[regression_train, 'train'], [regression_test, 'eval']]
+    )
+
+    assert_equal 1, callback.before_training_count
+    assert_equal 1, callback.after_training_count
+    assert_equal 8, callback.before_iteration_count
+    assert_equal 8, callback.after_iteration_count
+
+    # Verify arguments
+    train_rmse = callback.history['train']['rmse']
+    assert_equal 8, train_rmse.size
+    train_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+    eval_rmse = callback.history['eval']['rmse']
+    assert_equal 8, eval_rmse.size
+    eval_rmse.each do |value|
+      assert_in_delta 0.00, value, 1.0
+    end
+
+    epochs = callback.before_iteration_args.map { |e| e[:epoch] }
+    assert_equal (0...8).to_a, epochs
+  end
+
+  def test_updates_model_before_training
+    callback = MockCallback.new
+    def callback.before_training(model: nil)
+      model["device"] = "cuda:0"
+      return model
+    end
+
+    num_boost_round = 10
+
+    model = XGBoost.train(
+      regression_params,
+      regression_train,
+      num_boost_round: num_boost_round,
+      callbacks: [callback],
+      evals: [[regression_train, 'train'], [regression_test, 'eval']]
+    )
+
+    assert_equal model["device"], "cuda:0"
+  end
+end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
 class CallbacksTest < Minitest::Test
   class MockCallback < XGBoost::TrainingCallback
@@ -30,13 +30,13 @@ class CallbacksTest < Minitest::Test
     def before_iteration(model: nil, epoch: nil)
       @before_iteration_count += 1
       @before_iteration_args << { epoch: epoch }
-      return true
+      true
     end
 
     def after_iteration(model: nil, epoch: nil, history: nil)
       @after_iteration_count += 1
       @history = history
-      return true
+      true
     end
   end
 
@@ -92,7 +92,8 @@ class CallbacksTest < Minitest::Test
     def callback.before_iteration(model: nil, epoch: nil)
       @before_iteration_count += 1
       @before_iteration_args << { epoch: epoch }
-      return (epoch % 2 == 0)
+      # If any callback returns false, break
+      epoch.even?
     end
     num_boost_round = 10
 
@@ -130,7 +131,7 @@ class CallbacksTest < Minitest::Test
     def callback.after_iteration(model: nil, epoch: nil, history: nil)
       @after_iteration_count += 1
       @history = history
-      return epoch < 7
+      epoch < 7
     end
     num_boost_round = 10
 
@@ -166,8 +167,8 @@ class CallbacksTest < Minitest::Test
   def test_updates_model_before_training
     callback = MockCallback.new
     def callback.before_training(model: nil)
-      model["device"] = "cuda:0"
-      return model
+      model['device'] = 'cuda:0'
+      model
     end
 
     num_boost_round = 10
@@ -180,6 +181,6 @@ class CallbacksTest < Minitest::Test
       evals: [[regression_train, 'train'], [regression_test, 'eval']]
     )
 
-    assert_equal model["device"], "cuda:0"
+    assert_equal model['device'], 'cuda:0'
   end
 end


### PR DESCRIPTION
Hey Andrew! Thanks for this library 😄 

I wanted to add the [callbacks API](https://xgboost.readthedocs.io/en/stable/python/python_api.html#callback-api) so I could support an integration with [Wandb](https://github.com/wandb/wandb/blob/48dbe87faca6ad1f9fbfe7dd15c2a22e651cf145/wandb/integration/xgboost/xgboost.py) 

I have the Ruby implementation of this [callback over here](https://github.com/brettshollenberger/wandb_rb/blob/main/lib/wandb/xgboost_callback.rb) as an example of the use case and have tested the integration in my Wandb console

Some dummy data just to show the integration:
<img width="1136" alt="Screenshot 2024-10-11 at 2 36 17 PM" src="https://github.com/user-attachments/assets/82bc682e-6223-41ba-a063-f8ae2b585f98">
<img width="1420" alt="Screenshot 2024-10-11 at 2 35 55 PM" src="https://github.com/user-attachments/assets/5c3ffe8f-5790-43a0-918e-13062d06b20b">

I kept the API consistent w/ the Python implementation but let me know if there's anything else you'd want to see here
